### PR TITLE
Removed conditional forced peaceflower equip

### DIFF
--- a/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/bathmaid.dm
@@ -28,7 +28,7 @@
 			armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/random
 			pants = /obj/item/clothing/under/roguetown/tights/stockings/silk/random
 			wrists = /obj/item/clothing/neck/roguetown/psicross/eora
-			head  = /obj/item/clothing/head/peaceflower
+			// Bluemoon edit - Removed conditional forced peaceflower equip: head = /obj/item/clothing/head/peaceflower
 		else
 			shoes = /obj/item/clothing/shoes/roguetown/shortboots
 			shirt = /obj/item/clothing/suit/roguetown/shirt/undershirt

--- a/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/nightman.dm
@@ -59,7 +59,7 @@
 				shoes = /obj/item/clothing/shoes/roguetown/sandals
 				armor = /obj/item/clothing/suit/roguetown/shirt/dress/gen/strapless/random
 				wrists = /obj/item/clothing/neck/roguetown/psicross/eora
-				head  = /obj/item/clothing/head/peaceflower
+				// Bluemoon edit - Removed conditional forced peaceflower equip: head = /obj/item/clothing/head/peaceflower
 			else
 				armor = /obj/item/clothing/suit/roguetown/armor/armordress/alt
 				shoes = /obj/item/clothing/shoes/roguetown/shortboots


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the unremovable/cursed Peaceflower headpiece from the base equipment that forces pacifism on a female Viriitri-worshipping sex worker. (Nightmaidens and Nightmistress specifically)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Removes the extremely disproportionate sexism in this specific role.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
Removed one line of code respectively in:
\code\modules\jobs\job_types\roguetown\peasants\nightman.dm
\code\modules\jobs\job_types\roguetown\peasants\bathmaid.dm

:cl:
del: Removed old things
qol: made something easier to use
balance: rebalanced something
code: changed some code
/:cl:

<!-- The Changelog is not currently displayed in the game client, but this may change in the future. For this reason, the cl is identical in format to TGStation's listing. -->
